### PR TITLE
Hours improvements - add async select, rework update query

### DIFF
--- a/src/common/validators.ts
+++ b/src/common/validators.ts
@@ -35,3 +35,7 @@ export const createTagZod = z.object({
   name: z.string().min(1, 'Required'),
 });
 export type CreateTagInputs = z.infer<typeof createTagZod>;
+
+export const searchZod = z.object({
+  query: z.string().optional()
+}).default({})

--- a/src/pages/hours.tsx
+++ b/src/pages/hours.tsx
@@ -61,6 +61,7 @@ const CreateEditHour: FC<{ hourId?: string; onFinishEdit: () => void }> = ({
   );
   const { data: hour } = trpc.useQuery(['hours.single', { id: hourId ?? '' }], {
     enabled: Boolean(hourId),
+    refetchOnWindowFocus: false
   });
 
   const defaultValues = useMemo(
@@ -119,10 +120,10 @@ const CreateEditHour: FC<{ hourId?: string; onFinishEdit: () => void }> = ({
     };
     hour && hourId
       ? await editHour({
-          id: hourId,
-          oldTagIds: hour.tags?.map((t) => t.tagId) ?? [],
-          ...parsedData,
-        })
+        id: hourId,
+        oldTagIds: hour.tags?.map((t) => t.tagId) ?? [],
+        ...parsedData,
+      })
       : await createHour(parsedData);
     handleClose();
   };

--- a/src/pages/hours.tsx
+++ b/src/pages/hours.tsx
@@ -21,9 +21,11 @@ import Link from 'next/link';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Event } from 'react-big-calendar';
 import { Controller, useForm } from 'react-hook-form';
-import ReactSelect from 'react-select';
+import AsyncReactSelect from 'react-select/async';
+import { OptionValueLabel } from 'types';
 import { formatDatepicker, localizeUTCDate, parseDatepicker } from 'utils/date';
-import { trpc } from 'utils/trpc';
+import { debouncePromiseValue } from 'utils/delay';
+import { createTRPCVanillaClient, trpc } from 'utils/trpc';
 
 const emptyDefaultValues: Partial<CreateHourFormInputs> = {
   date: formatDatepicker(new Date()),
@@ -32,6 +34,20 @@ const emptyDefaultValues: Partial<CreateHourFormInputs> = {
   tagIds: [],
   value: '0',
 };
+
+const searchProjects = async (value: string) => {
+  const client = createTRPCVanillaClient()
+  const projects = await client.query('projects.search', { query: value })
+  return projects.map(p => ({ value: p.id, label: p.name }))
+}
+const debouncedSearchProjects: typeof searchProjects = debouncePromiseValue(searchProjects, 500)
+
+const searchTags = async (value: string) => {
+  const client = createTRPCVanillaClient()
+  const tags = await client.query('tags.search', { query: value })
+  return tags.map(t => ({ value: t.id, label: t.name }))
+}
+const debouncedSearchTags: typeof searchTags = debouncePromiseValue(searchTags, 500)
 
 const CreateEditHour: FC<{ hourId?: string; onFinishEdit: () => void }> = ({
   hourId,
@@ -95,22 +111,6 @@ const CreateEditHour: FC<{ hourId?: string; onFinishEdit: () => void }> = ({
     onFinishEdit();
     reset(emptyDefaultValues);
   };
-
-  const tagOptions = useMemo(() => {
-    if (!tags) return [];
-    return tags.map((t) => ({
-      value: t.id,
-      label: t.name,
-    }));
-  }, [tags]);
-
-  const projectOptions = useMemo(() => {
-    if (!projects) return [];
-    return projects.map((p) => ({
-      value: p.id,
-      label: p.name,
-    }));
-  }, [projects]);
 
   const onSubmit = async (data: CreateHourFormInputs) => {
     const parsedData: CreateHourInputs = {
@@ -184,15 +184,13 @@ const CreateEditHour: FC<{ hourId?: string; onFinishEdit: () => void }> = ({
           defaultValue={undefined}
           render={({ field }) => {
             return (
-              <ReactSelect
-                options={projectOptions}
+              <AsyncReactSelect<OptionValueLabel<string>>
+                defaultOptions
+                loadOptions={debouncedSearchProjects}
                 ref={field.ref}
                 onBlur={field.onBlur}
                 className="rounded text-black"
                 classNamePrefix="timetracky"
-                value={
-                  projectOptions.find((po) => po.value === field.value) ?? null
-                }
                 onChange={(value) => {
                   field.onChange(value?.value);
                 }}
@@ -219,17 +217,17 @@ const CreateEditHour: FC<{ hourId?: string; onFinishEdit: () => void }> = ({
           control={control}
           defaultValue={[]}
           render={({ field }) => (
-            <ReactSelect
+            <AsyncReactSelect<OptionValueLabel<string>, true>
               isMulti
-              options={tagOptions}
+              defaultOptions
+              loadOptions={debouncedSearchTags}
               onBlur={field.onBlur}
               ref={field.ref}
               className="text-black"
               classNamePrefix="timetracky"
               onChange={(value) => {
-                field.onChange(value.map((v) => v.value));
+                field.onChange(value.map((v) => v?.value));
               }}
-              value={tagOptions.filter((to) => field.value.includes(to.value))}
               placeholder="Select tags..."
             />
           )}

--- a/src/server/router/project-router.ts
+++ b/src/server/router/project-router.ts
@@ -1,7 +1,8 @@
 import { TRPCError } from '@trpc/server';
-import { identifiableZod } from 'common/validators';
+import { identifiableZod, searchZod } from 'common/validators';
 import { z } from 'zod';
 import { createRouter } from './context';
+
 
 export const projectRouter = createRouter()
   .query('exists', {
@@ -38,6 +39,15 @@ export const projectRouter = createRouter()
       });
       return projects;
     },
+  })
+  .query('search', {
+    input: searchZod, async resolve({ ctx, input: { query } }) {
+      // sigh typescript... It does not understand that 'insensitive' is a valid value
+      const whereClause: { name?: { contains?: string, mode?: 'insensitive' | 'default' } } | undefined = query ? { name: { contains: query, mode: 'insensitive' } } : undefined
+      return ctx.prisma.project.findMany({
+        where: whereClause
+      })
+    }
   })
   .mutation('create', {
     input: z.object({

--- a/src/server/router/tag-router.ts
+++ b/src/server/router/tag-router.ts
@@ -1,4 +1,4 @@
-import { createTagZod } from 'common/validators';
+import { createTagZod, searchZod } from 'common/validators';
 import { z } from 'zod';
 import { createRouter } from './context';
 
@@ -29,6 +29,17 @@ export const tagRouter = createRouter()
         }, 0),
       }));
     },
+  }).query('search', {
+    input: searchZod, async resolve({ ctx, input: { query } }) {
+      return ctx.prisma.tag.findMany({
+        where: {
+          name: {
+            contains: query,
+            mode: 'insensitive'
+          }
+        }
+      })
+    }
   })
   .mutation('create', {
     input: createTagZod,

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -1,0 +1,21 @@
+//@ts-nocheck
+/**
+ * Debounce a promise callback.
+ * @param fn A callback that returns a promise value
+ * @param timeout the time to wait until the function is called
+ * @returns a function reference that closures over a timeoutId. Returns a promise when called, if called again while its promise is unresolved it will reset the timeout, avoiding multiple calls during the timeout time
+ */
+export const debouncePromiseValue = <T = unknown>(fn, timeout: number) => {
+  let timeoutId;
+  return function(...args) {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    const promise = new Promise<T>((resolve) => {
+      timeoutId = setTimeout(() => {
+        resolve(fn(...args));
+      }, timeout);
+    });
+    return promise;
+  };
+};


### PR DESCRIPTION
- perf(hourRouter) ⚡ update in single transaction - Update hour tags in single transaction rather than doing that separatedly
- fix(hours):bug:remove refetchOnWindowsFocus
- feat(hours)✨make selects async
